### PR TITLE
RDPP-6938: bump z-schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/npm-debug.log
 
 coverage/
+dist/
 typings/
 .settings/
 .vscode/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
+## 2.1.1
+* patch: Bumped z-schema to 5.0.1 to resolve security issue.
+
 ## 2.1.0
-* major: Renamed from "sway" to "@axway/axsway"
-* major: Removed formatGenerators and dependencies faker, json-schema-faker
-* major: Removed dist files
-* patch: Fixed exceptions when loading OAS documents with extensions on paths and responses
+* major: Renamed from "sway" to "@axway/axsway".
+* major: Removed formatGenerators and dependencies faker, json-schema-faker.
+* major: Removed dist files.
+* patch: Fixed exceptions when loading OAS documents with extensions on paths and responses.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axway/axsway",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
     "path-to-regexp": "^1.7.0",
     "swagger-methods": "^1.0.0",
     "swagger-schema-official": "2.0.0-bab6bed",
-    "z-schema": "^3.22.0"
+    "z-schema": "^5.0.1"
   }
 }


### PR DESCRIPTION
z-schema major bumps from 3.x:
* 4.x: drop support for node < 10
* 5.x: breakOnFirstError default set to false, support node 14, drop support node 6

When they "dropped" support, these were really only talking about travis-ci.  There were no notable changes to [3.26.0 => 5.0.0](https://github.com/zaggino/z-schema/compare/v3.26.0...v5.0.0) that would break node-8.  The engines is still >= 8.